### PR TITLE
Add "auto" in the C++11 feature list

### DIFF
--- a/7.0.3/index.html
+++ b/7.0.3/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 
 
 <html lang="en">
@@ -278,6 +278,7 @@ needed.</p>
 <li>variadic templates</li>
 <li>type traits</li>
 <li>rvalue references</li>
+<li>placeholder type specifier (auto)</li>
 <li>decltype</li>
 <li>trailing return types</li>
 <li>deleted functions</li>


### PR DESCRIPTION
I thought you disallow `auto` because it was not in the list.
I'm not sure from when `auto` have existed in the code, but probably it was there since the release of 7.0.3 I guess.