### PR TITLE
Draft: Add Usage with Meson Section

### DIFF
--- a/10.1.0/_sources/usage.rst.txt
+++ b/10.1.0/_sources/usage.rst.txt
@@ -134,6 +134,29 @@ For ``build2`` newcomers or to get more details and use cases, you can read the
 ``build2``
 `toolchain introduction <https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml>`_.
 
+Usage with meson
+================
+
+`Meson's wrapdb <https://mesonbuild.com/Wrapdb-projects.html>` includes a fmt
+package, which repackages fmt to be built by meson as a subproject.
+
+**Usage:**
+
+- Install the ``fmt`` subproject from the wrapdb by running
+
+    meson wrap install fmt
+
+  from the root of your project
+
+- In your project's ``meson.build``` file, add an entry for the new subproject:
+
+    fmt = subproject('fmt')
+    fmt_dep = fmt.get_variable('fmt_dep')
+
+- Include the new dependency object to link with fmt:
+
+    my_build_target = executable('name', 'src/main.cc', dependencies: [fmt_dep])
+
 Building the Documentation
 ==========================
 


### PR DESCRIPTION
Adds a usage section for working with the meson build system.

Still needs to be done:
1. Regenerate HTML. I know this site is built with Sphinx, but I cannot find a `conf.py`, and cannot rebuild the site. Please let me know what I am missing!
2. Meson provides fmt version 10.1.1, 9.1.0, 9.0.0, 8.1.1, 8.0.1, 7.1.3, 7.0.1, 6.2.0, 6.0.0, 5.3.0, 5.2.1, 5.2.0, and 4.1.0. My changes are only for the latest version, but, if welcome, I could duplicate the documentation updates to all versions that meson provides.